### PR TITLE
Revert deprecated TextTheme usage and update to current standards

### DIFF
--- a/lib/ui/mobile_paged_listview.dart
+++ b/lib/ui/mobile_paged_listview.dart
@@ -210,7 +210,7 @@ class _NativePagedListViewState extends State<PagedListView> {
                             child: TextButton(
                               child: Text(
                                 "Close",
-                                style: Theme.of(context).textTheme.headline5,
+                                style: Theme.of(context).textTheme.headlineSmall,
                               ),
                               onPressed: () {
                                 _sortController!.close();

--- a/lib/ui/stateless_datatable.dart
+++ b/lib/ui/stateless_datatable.dart
@@ -149,7 +149,7 @@ class StatelessDataTable extends StatelessWidget {
       }).toList());
     }
 
-    final TextStyle? footerTextStyle = themeData.textTheme.caption;
+    final TextStyle? footerTextStyle = themeData.textTheme.bodySmall;
     final List<Widget> footerWidgets = <Widget>[];
     if (onRowsPerPageChanged != null) {
       final List<Widget> _footerChildren =
@@ -203,8 +203,8 @@ class StatelessDataTable extends StatelessWidget {
                 container: true,
                 child: DefaultTextStyle(
                   style: _selectedRowCount > 0
-                      ? themeData.textTheme.subtitle1!.copyWith(color: themeData.colorScheme.secondary)
-                      : themeData.textTheme.headline6!.copyWith(fontWeight: FontWeight.w400),
+                      ? themeData.textTheme.titleMedium!.copyWith(color: themeData.colorScheme.secondary)
+                      : themeData.textTheme.titleLarge!.copyWith(fontWeight: FontWeight.w400),
                   child: IconTheme.merge(
                     data: const IconThemeData(opacity: 0.54),
                     child: ButtonTheme(
@@ -269,8 +269,8 @@ class StatelessDataTable extends StatelessWidget {
               container: true,
               child: DefaultTextStyle(
                 style: _selectedRowCount > 0
-                    ? themeData.textTheme.subtitle1!.copyWith(color: themeData.colorScheme.secondary)
-                    : themeData.textTheme.headline6!.copyWith(fontWeight: FontWeight.w400),
+                    ? themeData.textTheme.titleMedium!.copyWith(color: themeData.colorScheme.secondary)
+                    : themeData.textTheme.titleLarge!.copyWith(fontWeight: FontWeight.w400),
                 child: IconTheme.merge(
                   data: const IconThemeData(opacity: 0.54),
                   child: ButtonTheme(


### PR DESCRIPTION
Flutter had deprecated some TextTheme ThemeData, and it was raising error on my project, so I forked and updated this package to follow newer Flutter versions